### PR TITLE
Fix missing project model for team and user route link

### DIFF
--- a/frontend/app/templates/team/edit.hbs
+++ b/frontend/app/templates/team/edit.hbs
@@ -6,7 +6,7 @@
   {{/active-link}}
 
   {{#active-link}}
-    {{#link-to 'team.edit.manage'}}Manage{{/link-to}}
+    {{#link-to 'team.edit.manage' model}}Manage{{/link-to}}
   {{/active-link}}
 </ul>
 

--- a/frontend/app/templates/user/edit.hbs
+++ b/frontend/app/templates/user/edit.hbs
@@ -6,7 +6,7 @@
   {{/active-link}}
 
   {{#active-link}}
-    {{#link-to 'user.edit.worktime'}}Worktime{{/link-to}}
+    {{#link-to 'user.edit.worktime' model}}Worktime{{/link-to}}
   {{/active-link}}
 </ul>
 


### PR DESCRIPTION
This fixes an error caused by transitioning away from user.edit and
team.edit